### PR TITLE
refactor(config): 修改 AppConfig 的获取方式, 便于编写测试用例.

### DIFF
--- a/scalabot-app/src/main/kotlin/AppConfigs.kt
+++ b/scalabot-app/src/main/kotlin/AppConfigs.kt
@@ -106,7 +106,7 @@ internal data class MavenRepositoryConfig(
     val authentication: Authentication? = null
 ) {
 
-    fun toRemoteRepository(proxyConfig: ProxyConfig = Const.config.proxy): RemoteRepository {
+    fun toRemoteRepository(proxyConfig: ProxyConfig): RemoteRepository {
         val builder = RemoteRepository.Builder(null, checkRepositoryLayout(layout), url.toString())
         if (proxy != null) {
             builder.setProxy(proxy)

--- a/scalabot-app/src/main/kotlin/AppConfigs.kt
+++ b/scalabot-app/src/main/kotlin/AppConfigs.kt
@@ -106,12 +106,12 @@ internal data class MavenRepositoryConfig(
     val authentication: Authentication? = null
 ) {
 
-    fun toRemoteRepository(): RemoteRepository {
+    fun toRemoteRepository(proxyConfig: ProxyConfig = Const.config.proxy): RemoteRepository {
         val builder = RemoteRepository.Builder(null, checkRepositoryLayout(layout), url.toString())
         if (proxy != null) {
             builder.setProxy(proxy)
-        } else if (Const.config.proxy.type == DefaultBotOptions.ProxyType.HTTP) {
-            builder.setProxy(Const.config.proxy.toAetherProxy())
+        } else if (proxyConfig.type == DefaultBotOptions.ProxyType.HTTP) {
+            builder.setProxy(proxyConfig.toAetherProxy())
         }
         return builder.build()
     }

--- a/scalabot-app/src/main/kotlin/AppMain.kt
+++ b/scalabot-app/src/main/kotlin/AppMain.kt
@@ -123,7 +123,7 @@ internal class Launcher(private val config: AppConfig = Const.config) : AutoClos
         val account = botConfig.account
 
         val remoteRepositories = config.mavenRepositories
-            .map(MavenRepositoryConfig::toRemoteRepository)
+            .map { it.toRemoteRepository(config.proxy) }
             .toMutableList().apply {
                 if (this.none {
                         it.url == MavenRepositoryExtensionFinder.MAVEN_CENTRAL_URL

--- a/scalabot-app/src/main/kotlin/AppMain.kt
+++ b/scalabot-app/src/main/kotlin/AppMain.kt
@@ -22,9 +22,7 @@ fun main(args: Array<String>): Unit = runBlocking {
 
     val launcher = Launcher()
         .registerShutdownHook()
-    if (Const.config.metrics.enable) {
-        startMetricsServer()
-    }
+    startMetricsServer()
     if (!launcher.launch()) {
         exitProcess(1)
     }
@@ -34,11 +32,16 @@ fun main(args: Array<String>): Unit = runBlocking {
  * 启动运行指标服务器.
  * 使用 Prometheus 指标格式.
  */
-fun startMetricsServer() {
+internal fun startMetricsServer(config: MetricsConfig = Const.config.metrics) {
+    if (!config.enable) {
+        log.debug { "运行指标服务器已禁用." }
+        return
+    }
+
     val builder = HTTPServer.Builder()
         .withDaemonThreads(true)
-        .withPort(Const.config.metrics.port)
-        .withHostname(Const.config.metrics.bindAddress)
+        .withPort(config.port)
+        .withHostname(config.bindAddress)
 
     val httpServer = builder
         .build()
@@ -46,7 +49,7 @@ fun startMetricsServer() {
     log.info { "运行指标服务器已启动. (Port: ${httpServer.port})" }
 }
 
-internal class Launcher : AutoCloseable {
+internal class Launcher(private val config: AppConfig = Const.config) : AutoCloseable {
 
     companion object {
         @JvmStatic
@@ -59,9 +62,9 @@ internal class Launcher : AutoCloseable {
 
     private fun getMavenLocalRepository(): LocalRepository {
         val localPath =
-            if (Const.config.mavenLocalRepository != null && Const.config.mavenLocalRepository.isNotEmpty()) {
+            if (config.mavenLocalRepository != null && config.mavenLocalRepository.isNotEmpty()) {
                 val repoPath = AppPaths.DATA_ROOT.file.toPath()
-                    .resolve(Const.config.mavenLocalRepository)
+                    .resolve(config.mavenLocalRepository)
                     .toRealPath()
                     .toFile()
                 repoPath
@@ -101,15 +104,15 @@ internal class Launcher : AutoCloseable {
             val proxyConfig =
                 if (botConfig.proxy != null && botConfig.proxy.type != DefaultBotOptions.ProxyType.NO_PROXY) {
                     botConfig.proxy
-                } else if (Const.config.proxy.type != DefaultBotOptions.ProxyType.NO_PROXY) {
-                    Const.config.proxy
+                } else if (config.proxy.type != DefaultBotOptions.ProxyType.NO_PROXY) {
+                    config.proxy
                 } else {
                     null
                 }
             if (proxyConfig != null) {
                 proxyType = proxyConfig.type
-                proxyHost = Const.config.proxy.host
-                proxyPort = Const.config.proxy.port
+                proxyHost = config.proxy.host
+                proxyPort = config.proxy.port
                 log.debug { "机器人 `${botConfig.account.name}` 已启用代理配置: $proxyConfig" }
             }
 
@@ -119,21 +122,21 @@ internal class Launcher : AutoCloseable {
         }
         val account = botConfig.account
 
-        val remoteRepositories = Const.config.mavenRepositories
+        val remoteRepositories = config.mavenRepositories
             .map(MavenRepositoryConfig::toRemoteRepository)
             .toMutableList().apply {
                 if (this.none {
                         it.url == MavenRepositoryExtensionFinder.MAVEN_CENTRAL_URL
                                 || it.url == MavenRepositoryExtensionFinder.MAVEN_CENTRAL_URL.trimEnd('/')
                     }) {
-                    add(MavenRepositoryExtensionFinder.getMavenCentralRepository(proxy = Const.config.proxy.toAetherProxy()))
+                    add(MavenRepositoryExtensionFinder.getMavenCentralRepository(proxy = config.proxy.toAetherProxy()))
                 }
             }.toList()
         val extensionPackageFinders = setOf(
             MavenRepositoryExtensionFinder(
                 localRepository = mavenLocalRepository,
                 remoteRepositories = remoteRepositories,
-                proxy = Const.config.proxy.toAetherProxy()
+                proxy = config.proxy.toAetherProxy()
             )
         )
 


### PR DESCRIPTION
通过 Const 单例对象获取配置信息不利于编写测试用例, 所以改为利用参数的默认值来获取 Const 的 config 对象.

Issue #5