### PR TITLE
ci(github-action): 增加 Dependabot 配置文件.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gradle"
+    directory: "/scalabot-app"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/scalabot-meta"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/scalabot-extension"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/scalabot-ext-example"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
使用 Dependabot 来自动检查依赖新版本, 减轻工作量.