### PR TITLE
build(deps): bump org.telegram:telegrambots-abilities from 6.7.0 to 6…

### DIFF
--- a/scalabot-app/build.gradle.kts
+++ b/scalabot-app/build.gradle.kts
@@ -29,8 +29,8 @@ dependencies {
 
     implementation("org.jdom:jdom2:2.0.6.1")
 
-    implementation("org.telegram:telegrambots-abilities:6.7.0")
-    implementation("org.telegram:telegrambots:6.7.0")
+    implementation("org.telegram:telegrambots-abilities:6.8.0")
+    implementation("org.telegram:telegrambots:6.8.0")
 
     implementation("io.prometheus:simpleclient:0.16.0")
     implementation("io.prometheus:simpleclient_httpserver:0.16.0")

--- a/scalabot-extension/build.gradle.kts
+++ b/scalabot-extension/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 dependencies {
     implementation("commons-codec:commons-codec:1.16.0")
-    api("org.telegram:telegrambots-abilities:6.7.0")
+    api("org.telegram:telegrambots-abilities:6.8.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation("org.mockito:mockito-core:5.8.0")

--- a/scalabot-meta/build.gradle.kts
+++ b/scalabot-meta/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     api("org.eclipse.aether:aether-api:$aetherVersion")
     implementation("org.eclipse.aether:aether-util:$aetherVersion")
 
-    implementation("org.telegram:telegrambots-meta:6.7.0")
+    implementation("org.telegram:telegrambots-meta:6.8.0")
 
     api("com.google.code.gson:gson:2.10.1")
 


### PR DESCRIPTION
….8.0

Bumps [org.telegram:telegrambots-abilities](https://github.com/rubenlagus/TelegramBots) from 6.7.0 to 6.8.0.
- [Release notes](https://github.com/rubenlagus/TelegramBots/releases)
- [Commits](rubenlagus/TelegramBots@v6.7.0...v6.8.0)

---
updated-dependencies:
- dependency-name: org.telegram:telegrambots-abilities dependency-type: direct:production update-type: version-update:semver-minor ...